### PR TITLE
fix(makepkg): using compression level 20 instead of 22

### DIFF
--- a/makepkg.d/makepkg.base.conf
+++ b/makepkg.d/makepkg.base.conf
@@ -114,7 +114,7 @@ GPGKEY="4A0F0C8BC709ACA4341767FB243975C8DB9656B9"
 COMPRESSGZ=(gzip -c -f -n)
 COMPRESSBZ2=(bzip2 -c -f)
 COMPRESSXZ=(xz -c -z -)
-COMPRESSZST=(zstd -c -z -q --ultra -22 --threads=0 -)
+COMPRESSZST=(zstd -c -z -q --ultra -20 --threads=0 -)
 COMPRESSLRZ=(lrzip -q)
 COMPRESSLZO=(lzop -q)
 COMPRESSZ=(compress -c -f)


### PR DESCRIPTION
As Arch Linux does, we use level 20.
Level 22 use too much memory.