### PR TITLE
feat(makepkg): enable Link-Time Optimization by default

### DIFF
--- a/makepkg.d/makepkg.base.conf
+++ b/makepkg.d/makepkg.base.conf
@@ -69,7 +69,7 @@ BUILDENV=(!distcc color !ccache check sign)
 #-- debug:      Add debugging flags as specified in DEBUG_* variables
 #-- lto:        Add compile flags for building with link time optimization
 #
-OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge !debug !lto)
+OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge !debug lto)
 
 #-- File integrity checks to use. Valid: md5, sha1, sha224, sha256, sha384, sha512, b2
 INTEGRITY_CHECK=(sha512 b2)


### PR DESCRIPTION
[1]: Arch Linux RFC4: https://gitlab.archlinux.org/archlinux/rfcs/-/blob/master/rfcs/0004-lto-by-default.rst